### PR TITLE
Fix font constant and euro symbol

### DIFF
--- a/ETHPriceWidget/source/ETHPriceView.mc
+++ b/ETHPriceWidget/source/ETHPriceView.mc
@@ -29,8 +29,8 @@ function onUpdate(dc as Gfx.Dc) {
     dc.clear();
     dc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
 
-    dc.drawText(w/2, (h*30)/100, Gfx.FONT_XLARGE, "ETH", Gfx.TEXT_JUSTIFY_CENTER);
-    dc.drawText(w/2, (h*55)/100, Gfx.FONT_LARGE, _priceStr + " Ã¢â€šÂ¬", Gfx.TEXT_JUSTIFY_CENTER);
+    dc.drawText(w/2, (h*30)/100, Gfx.FONT_MEDIUM, "ETH", Gfx.TEXT_JUSTIFY_CENTER);
+    dc.drawText(w/2, (h*55)/100, Gfx.FONT_LARGE, _priceStr + " €", Gfx.TEXT_JUSTIFY_CENTER);
     dc.drawText(w/2, (h*80)/100, Gfx.FONT_SMALL, "Maj: " + _lastUpdated, Gfx.TEXT_JUSTIFY_CENTER);
 }
 


### PR DESCRIPTION
## Summary
- Replace unsupported FONT_XLARGE with FONT_MEDIUM and FONT_LARGE
- Correct euro symbol in price display

## Testing
- `monkeyc -o ETHPriceWidget.prg -f monkey.jungle -d fenix7pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bc489946d48333a7d1f62ecf2d0c4e